### PR TITLE
JPMS Strictly Named Modules

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
   <groupId>com.fasterxml.jackson</groupId>
   <artifactId>jackson-parent</artifactId>
-  <version>2.9.1.2-SNAPSHOT</version>
+    <version>2.9.1.1</version>
   <packaging>pom</packaging>
 
   <name>Jackson parent poms</name>
@@ -54,14 +54,24 @@
   </scm>
 
   <properties>
-    <jackson.version.annotations>2.9.0</jackson.version.annotations>
+      <jackson.version.annotations>2.9.8-SNAPSHOT</jackson.version.annotations>
 
     <!-- 02-Oct-2015, tatu: Jackson 2.4 and above are Java 6 (earlier versions Java 5);
           Jackson 2.7 and above Java 7 (with exception of `jackson-core`/`jackson-annotations` still Java 6),
       -->
     <javac.src.version>1.7</javac.src.version>
     <javac.target.version>1.7</javac.target.version>
-    <javac.debuglevel>lines,source,vars</javac.debuglevel>
+
+      <!-- TODO Remove JDK 11 Settings -->
+      <javac.src.version>1.11</javac.src.version>
+      <javac.target.version>1.11</javac.target.version>
+
+      <jdk.version>1.11</jdk.version>
+      <maven.compiler.source>1.11</maven.compiler.source>
+      <maven.compiler.target>1.11</maven.compiler.target>
+      <maven.compiler.release>11</maven.compiler.release>
+
+      <javac.debuglevel>lines,source,vars</javac.debuglevel>
 
     <!-- Versions for other dependencies -->
     <version.junit>4.12</version.junit>
@@ -208,8 +218,42 @@
             </lifecycleMappingMetadata>
           </configuration>
         </plugin>
+
+          <plugin>
+              <!-- In the future, rather than using ModiTect to compile module-info.java,
+                  could use two execute rules: https://maven.apache.org/plugins/maven-compiler-plugin/examples/module-info.html -->
+              <groupId>org.moditect</groupId>
+              <artifactId>moditect-maven-plugin</artifactId>
+              <version>1.0.0.Beta1</version>
+              <executions>
+                  <execution>
+                      <id>add-module-infos</id>
+                      <phase>package</phase>
+                      <goals>
+                          <goal>add-module-info</goal>
+                      </goals>
+                      <configuration>
+                          <overwriteExistingFiles>true</overwriteExistingFiles>
+                          <module>
+                              <moduleInfoFile>
+                                  src/moditect/module-info.java
+                              </moduleInfoFile>
+                          </module>
+                      </configuration>
+                  </execution>
+              </executions>
+          </plugin>
+
       </plugins>
     </pluginManagement>
   </build>
 
+    <profiles>
+        <profile>
+            <id>JPMS</id>
+            <activation>
+                <jdk>1.11</jdk>
+            </activation>
+        </profile>
+    </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
    <groupId>com.fasterxml</groupId>
     <artifactId>oss-parent</artifactId>
-    <version>33</version>
+    <version>35-SNAPSHOT</version>
   </parent>
 
   <groupId>com.fasterxml.jackson</groupId>
@@ -76,8 +76,10 @@
      | packageVersion.dir and packageVersion.package, and must set the phase of the
      | process-packageVersion execution of maven-replacer-plugin to 'generate-sources'.
     -->
-    <packageVersion.template.input>${basedir}/src/main/java/${packageVersion.dir}/PackageVersion.java.in</packageVersion.template.input>
-    <packageVersion.template.output>${generatedSourcesDir}/${packageVersion.dir}/PackageVersion.java</packageVersion.template.output>
+    <!--suppress UnresolvedMavenProperty -->
+      <packageVersion.template.input>${basedir}/src/main/java/${packageVersion.dir}/PackageVersion.java.in</packageVersion.template.input>
+    <!--suppress UnresolvedMavenProperty -->
+      <packageVersion.template.output>${generatedSourcesDir}/${packageVersion.dir}/PackageVersion.java</packageVersion.template.output>
 
   </properties>
 
@@ -101,22 +103,6 @@
   </dependencyManagement>
 
   <build>
-
-	<plugins>
-		 <plugin>
-			<groupId>org.apache.maven.plugins</groupId>
-			<artifactId>maven-compiler-plugin</artifactId>
-			<version>3.8.0</version>
-			<dependencies>
-				<dependency>
-					<groupId>org.ow2.asm</groupId>
-					<artifactId>asm</artifactId>
-					<version>7.0</version>
-				</dependency>
-			</dependencies>
-		</plugin>
-	</plugins>
-  
     <pluginManagement>
       <plugins>
 
@@ -184,18 +170,23 @@
             <outputFile>${packageVersion.template.output}</outputFile>
             <replacements>
               <replacement>
-                <token>@package@</token>
+                <!--suppress UnresolvedMavenProperty -->
+                  <token>@package@</token>
+                  <!--suppress UnresolvedMavenProperty -->
                 <value>${packageVersion.package}</value>
               </replacement>
               <replacement>
+                  <!--suppress UnresolvedMavenProperty -->
                 <token>@projectversion@</token>
                 <value>${project.version}</value>
               </replacement>
               <replacement>
+                  <!--suppress UnresolvedMavenProperty -->
                 <token>@projectgroupid@</token>
                 <value>${project.groupId}</value>
               </replacement>
               <replacement>
+                  <!--suppress UnresolvedMavenProperty -->
                 <token>@projectartifactid@</token>
                 <value>${project.artifactId}</value>
               </replacement>
@@ -313,11 +304,7 @@
                                 <version>7.0</version>
                             </dependency>
                         </dependencies>
-                        <configuration>
-                            <release>1.11</release>
-                        </configuration>
                     </plugin>
-
                 </plugins>
             </build>
         </profile>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,8 @@
 
   <groupId>com.fasterxml.jackson</groupId>
   <artifactId>jackson-parent</artifactId>
-    <version>2.9.1.1</version>
+  <version>2.9.1.2</version>
+
   <packaging>pom</packaging>
 
   <name>Jackson parent poms</name>
@@ -59,17 +60,11 @@
     <!-- 02-Oct-2015, tatu: Jackson 2.4 and above are Java 6 (earlier versions Java 5);
           Jackson 2.7 and above Java 7 (with exception of `jackson-core`/`jackson-annotations` still Java 6),
       -->
-    <javac.src.version>1.7</javac.src.version>
-    <javac.target.version>1.7</javac.target.version>
+      <javac.src.version>1.7</javac.src.version>
+      <javac.target.version>1.7</javac.target.version>
 
-      <!-- TODO Remove JDK 11 Settings -->
-      <javac.src.version>1.11</javac.src.version>
-      <javac.target.version>1.11</javac.target.version>
-
-      <jdk.version>1.11</jdk.version>
-      <maven.compiler.source>1.11</maven.compiler.source>
-      <maven.compiler.target>1.11</maven.compiler.target>
-      <maven.compiler.release>11</maven.compiler.release>
+      <maven.compiler.source>1.7</maven.compiler.source>
+      <maven.compiler.target>1.7</maven.compiler.target>
 
       <javac.debuglevel>lines,source,vars</javac.debuglevel>
 
@@ -106,6 +101,22 @@
   </dependencyManagement>
 
   <build>
+
+	<plugins>
+		 <plugin>
+			<groupId>org.apache.maven.plugins</groupId>
+			<artifactId>maven-compiler-plugin</artifactId>
+			<version>3.8.0</version>
+			<dependencies>
+				<dependency>
+					<groupId>org.ow2.asm</groupId>
+					<artifactId>asm</artifactId>
+					<version>7.0</version>
+				</dependency>
+			</dependencies>
+		</plugin>
+	</plugins>
+  
     <pluginManagement>
       <plugins>
 
@@ -218,42 +229,97 @@
             </lifecycleMappingMetadata>
           </configuration>
         </plugin>
-
-          <plugin>
-              <!-- In the future, rather than using ModiTect to compile module-info.java,
-                  could use two execute rules: https://maven.apache.org/plugins/maven-compiler-plugin/examples/module-info.html -->
-              <groupId>org.moditect</groupId>
-              <artifactId>moditect-maven-plugin</artifactId>
-              <version>1.0.0.Beta1</version>
-              <executions>
-                  <execution>
-                      <id>add-module-infos</id>
-                      <phase>package</phase>
-                      <goals>
-                          <goal>add-module-info</goal>
-                      </goals>
-                      <configuration>
-                          <overwriteExistingFiles>true</overwriteExistingFiles>
-                          <module>
-                              <moduleInfoFile>
-                                  src/moditect/module-info.java
-                              </moduleInfoFile>
-                          </module>
-                      </configuration>
-                  </execution>
-              </executions>
-          </plugin>
-
       </plugins>
     </pluginManagement>
+
+
   </build>
 
     <profiles>
         <profile>
-            <id>JPMS</id>
-            <activation>
-                <jdk>1.11</jdk>
-            </activation>
+            <id>jdk11</id>
+            <properties>
+                <javac.src.version>1.11</javac.src.version>
+                <javac.target.version>1.11</javac.target.version>
+
+                <jdk.version>1.11</jdk.version>
+                <maven.compiler.source>1.11</maven.compiler.source>
+                <maven.compiler.target>1.11</maven.compiler.target>
+                <maven.compiler.release>1.11</maven.compiler.release>
+            </properties>
+            <!-- Not Necessary, but useful-->
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <version>2.22.0</version>
+                        <configuration>
+                            <skipTests>false</skipTests>
+                            <argLine>
+                                --illegal-access=permit
+                            </argLine>
+                            <excludes>
+                                <exclude>com/fasterxml/jackson/**/failing/*.java</exclude>
+                            </excludes>
+                        </configuration>
+                    </plugin>
+                    <!-- Yes.. -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <version>3.0.1</version>
+                        <configuration>
+                            <detectJavaApiLink>false</detectJavaApiLink>
+                            <offlineLinks>
+                                <offlineLink>
+                                    <url>https://docs.oracle.com/javase/${maven.compiler.release}/docs/api/</url>
+                                    <location>${project.basedir}</location>
+                                </offlineLink>
+                            </offlineLinks>
+                            <failOnError>false</failOnError>
+                        </configuration>
+                    </plugin>
+                    <!-- Allows you to switch builds quickly and make sure it all works-->
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>build-helper-maven-plugin</artifactId>
+                        <version>1.7</version>
+                        <executions>
+                            <execution>
+                                <id>add-source</id>
+                                <phase>generate-sources</phase>
+                                <goals>
+                                    <goal>add-source</goal>
+                                </goals>
+                                <configuration>
+                                    <sources>
+                                        <source>src/moditect</source>
+                                        <source>src/main/java</source>
+                                    </sources>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <version>3.8.0</version>
+                        <dependencies>
+                            <dependency>
+                                <groupId>org.ow2.asm</groupId>
+                                <artifactId>asm</artifactId>
+                                <version>7.0</version>
+                            </dependency>
+                        </dependencies>
+                        <configuration>
+                            <release>1.11</release>
+                        </configuration>
+                    </plugin>
+
+                </plugins>
+            </build>
         </profile>
     </profiles>
 </project>


### PR DESCRIPTION
* JAXB Bump to 2.3.0
* Guice Minimum set to 4.2.2 for JPMS
* JSON Setter - couldn't find merge annotation method on branch 2.9
* JPMS Strictly Named Modules with Hard Exports ONLY

JPMS Considerations
===================
For Private/Protected Field Scanning, The required package should open to com.fasterxml.jackson.databind.
This is how it currently works with automatic module naming, but it is now strictly enforced